### PR TITLE
Allow to read (only) image when they are stored in the HDU 0. 

### DIFF
--- a/src/test/scala/com/sparkfits/FitsLibTest.scala
+++ b/src/test/scala/com/sparkfits/FitsLibTest.scala
@@ -40,6 +40,13 @@ class FitsLibTest extends FunSuite with BeforeAndAfterAll {
     assert(fB1.isInstanceOf[Fits])
   }
 
+  // need to expand for other data type stored in the HDU 0...
+  test("FitsLib test: Can you read an Image stored in the 0th HDU?") {
+    val file0 = new Path("src/test/resources/toTest/tst0001.fits")
+    val fB1 = new Fits(file0, conf, 0)
+    assert(fB1.isInstanceOf[Fits])
+  }
+
   // Check that the HDU asked is below the max HDU index.
   test("FitsLib test: Can you detect wrong HDU index?") {
     val exception = intercept[AssertionError] {


### PR DESCRIPTION
For some obscure reason, the data type is not declared in the HDU 0,
and therefore the previous piece of code couldn't detect the data type.
In 99% of the case, people store image in this zeroth HDU, so I will
assume this. This is not bug-free of course, and I might have to change this
in the future. The reason why I'm spending plenty of time to describe
a potential error instead of fixing it is that I do not know exactly
how to fix it. Any ideas?