### PR TITLE
Reading Image HDU: a row can be missing

### DIFF
--- a/run_java.sh
+++ b/run_java.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018 Julien Peloton
+# Copyright 2018 AstroLab Software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/java/com/astrolabsoftware/sparkfits/ReadFitsJ.java
+++ b/src/main/java/com/astrolabsoftware/sparkfits/ReadFitsJ.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 AstroLab Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.astrolabsoftware.sparkfits;
 
 import org.apache.spark.sql.SparkSession;
@@ -15,16 +30,16 @@ public class ReadFitsJ {
     Logger.getLogger("akka").setLevel(Level.WARN);
     spark = SparkSession.builder()
                         .master("local")
-                        .appName("ReadFits")
+                        .appName("ReadFitsJ")
                         .getOrCreate();
     }
 
   public static void main(String[] args) {
     for (int hdu : new Integer[]{2}) {
       Dataset<Row> df = spark.read()
-                             .format("com.astrolabsoftware.sparkfits")
+                             .format("fits")
                              .option("hdu", hdu)
-                             .option("verbose", true) 
+                             .option("verbose", true)
                              .option("recordlength", 1 * 1024)
                              .load(args[0].toString());
       log.info("show>");
@@ -35,8 +50,8 @@ public class ReadFitsJ {
       }
     }
 
-  private static SparkSession spark;  
-    
+  private static SparkSession spark;
+
   private static Logger log = Logger.getLogger(ReadFitsJ.class);
-  
+
   }

--- a/src/main/scala/com/astrolabsoftware/sparkfits/ReadFits.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/ReadFits.scala
@@ -34,9 +34,9 @@ object ReadFits {
   def main(args : Array[String]) = {
 
     // Loop over the two HDU of the test file
-    for (hdu <- 2 to 2) {
+    for (hdu <- 1 to 2) {
       val df = spark.read
-        .format("com.astrolabsoftware.sparkfits")
+        .format("fits")
         .option("hdu", hdu)                 // Index of the HDU
         .option("verbose", true)            // pretty print
         .option("recordlength", 1 * 1024)   // 1 KB per record


### PR DESCRIPTION
I noticed that when an image is split across several HDFS blocks, the transition is not done correctly, and there is one row typically missing. After some manual inspection, I found that introducing a shift in the starting index of [FitsRecordReader.scala](https://github.com/astrolabsoftware/spark-fits/blob/master/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala) helps removing the bug. The shift is function of the HDU index, and depends whether the primary HDU is empty or not:

```scala
var shift = if (primaryfits.empty_hdu) {
    FITSBLOCK_SIZE_BYTES * (conf.get("hdu").toInt - 3)
} else {
    FITSBLOCK_SIZE_BYTES * (conf.get("hdu").toInt - 1)
}
```

By far I'm not convinced about this fix as a _general solution_, but it works on the few examples that I tried. If you face again a similar problem, or find a general solution, let me know!