### PR TITLE
Add possibility to apply glob on input folder 

### DIFF
--- a/docs/02_api.md
+++ b/docs/02_api.md
@@ -57,7 +57,8 @@ Note that the file can be in a local system
 (`path="file://path/myfile.fits"`) or in HDFS
 (`path="hdfs://<IP>:<PORT>//path/myfile.fits"`). You can also specify a
 directory containing a set of FITS files
-(`path="hdfs://<IP>:<PORT>//path_to_dir"`) with the same HDU structure.
+(`path="hdfs://<IP>:<PORT>//path_to_dir"`) with the same HDU structure, or you
+can apply globbing patterns (`path="hdfs://<IP>:<PORT>//path_to_dir/*.fits"`).
 The connector will load the data from the same HDU from all the files in
 one single DataFrame. This is particularly useful to manipulate many
 small files written the same way as one.

--- a/src/test/scala/com/astrolabsoftware/sparkfits/packageTest.scala
+++ b/src/test/scala/com/astrolabsoftware/sparkfits/packageTest.scala
@@ -150,6 +150,19 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
       .option("recordlength", 16 * 1024)
 
     assert(results.load(fn).isInstanceOf[DataFrame])
+    assert(results.load(fn).count() == 27000)
+  }
+
+  test("Multi files test: Can you read several FITS file (glob)?") {
+    val fn = "src/test/resources/dir/*.fits"
+    val df = spark.read.format("com.astrolabsoftware.sparkfits")
+      .option("hdu", 1)
+      .option("verbose", true)
+      .option("recordlength", 16 * 1024)
+      .load(fn)
+
+    assert(df.isInstanceOf[DataFrame])
+    assert(df.count() == 27000)
   }
 
   test("Multi files test: Can you detect an error in reading different FITS file?") {


### PR DESCRIPTION
### What has changed/added?

Data can now be loaded from glob pattern:

```scala
// Already available (one file)
val fn = "hdfs:///my/folder/myfile.fits"
val df = spark.format("fits").option("hdu", 1).load(fn)

// Already available (entire folder)
val fn = "hdfs:///my/folder"
val df = spark.format("fits").option("hdu", 1).load(fn)

// NEW (files matching pattern)
val fn = "hdfs:///my/folder/*.fits"
val df = spark.format("fits").option("hdu", 1).load(fn)
```

### How this has been tested?

Unit test added (`packageTest.scala`) + manual inspection.