### PR TITLE
Update Jekyll version to fix known vulnerability

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.3)
+    jekyll (3.8.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -28,11 +28,11 @@ GEM
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
     jekyll-feed (0.10.0)
-      jekyll (~> 3.3)
+      jekyll (~> 3.8.4)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.5.0)
-      jekyll (~> 3.3)
+      jekyll (~> 3.8.4)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
     kramdown (1.17.0)
@@ -43,7 +43,7 @@ GEM
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
     minima (2.5.0)
-      jekyll (~> 3.5)
+      jekyll (~> 3.8.4)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     pathutil (0.16.1)
@@ -65,7 +65,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.8.3)
+  jekyll (~> 3.8.4)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data


### PR DESCRIPTION
In response to

<img width="1018" alt="screen shot 2018-10-10 at 13 31 50" src="https://user-images.githubusercontent.com/20426972/46733522-e094b880-cc90-11e8-98b3-53d53fdbcfe2.png">
