### PR TITLE
Issues/54: on the multifile problem in spark-fits

### DIFF
--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
@@ -313,14 +313,19 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     // }
 
     // Union if more than one file
+    // val rdd = if (implemented) {
+    //   sqlContext.sparkContext.union(
+    //     fns.map(file => loadOneHDU(fns.mkString(",")))
+    //   )
+    // } else {
+    //   sqlContext.sparkContext.union(
+    //     fns.map(file => loadOneEmpty)
+    //   )
+    // }
     val rdd = if (implemented) {
-      sqlContext.sparkContext.union(
-        fns.map(file => loadOneHDU(file))
-      )
+      loadOneHDU(fns.mkString(","))
     } else {
-      sqlContext.sparkContext.union(
-        fns.map(file => loadOneEmpty)
-      )
+      loadOneEmpty
     }
     // val rdd = sqlContext.sparkContext.union(
     //   fns.map(file => loadOneHDU(file))
@@ -348,25 +353,25 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
   def loadOneHDU(fn : String): RDD[Row] = {
 
     // Open one file
-    val path = new Path(fn)
-    val indexHDU = conf.get("hdu").toInt
-    val fits = new Fits(path, conf, indexHDU)
-
-    // Register header and block boundaries in the Hadoop configuration
-    fits.registerHeader
-    fits.blockBoundaries.register(path, conf)
-
-    // Check the header if needed
-    if (verbosity) {
-      println(s"+------ FILE $fn ------+")
-      println(s"+------ HEADER (HDU=$indexHDU) ------+")
-      fits.blockHeader.foreach(println)
-      println("+----------------------------+")
-    }
-
-    // We do not need the data on the driver at this point.
-    // The executors will re-open it later on.
-    fits.data.close()
+    // val path = new Path(fn)
+    // val indexHDU = conf.get("hdu").toInt
+    // val fits = new Fits(path, conf, indexHDU)
+    //
+    // // Register header and block boundaries in the Hadoop configuration
+    // fits.registerHeader
+    // fits.blockBoundaries.register(path, conf)
+    //
+    // // Check the header if needed
+    // if (verbosity) {
+    //   println(s"+------ FILE $fn ------+")
+    //   println(s"+------ HEADER (HDU=$indexHDU) ------+")
+    //   fits.blockHeader.foreach(println)
+    //   println("+----------------------------+")
+    // }
+    //
+    // // We do not need the data on the driver at this point.
+    // // The executors will re-open it later on.
+    // fits.data.close()
 
     // Distribute the table data
     sqlContext.sparkContext.newAPIHadoopFile(fn,

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
@@ -282,6 +282,8 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
 
     // Load one or all the FITS files found
     load(listOfFitsFiles, implemented)
+    // sqlContext.sparkContext.setCheckpointDir("file:///Users/julien/Documents/workspace/myrepos/spark-fits/checkpoint")
+    // rdd.checkpoint()
   }
 
   /**
@@ -304,21 +306,36 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     val nFiles = fns.size
 
     // Initialise
-    var rdd = if (implemented) {
-      loadOneHDU(fns(0))
-    } else {
-      loadOneEmpty
-    }
+    // var rdd = if (implemented) {
+    //   loadOneHDU(fns(0))
+    // } else {
+    //   loadOneEmpty
+    // }
 
     // Union if more than one file
-    for ((file, index) <- fns.slice(1, nFiles).zipWithIndex) {
-      rdd = if (implemented) {
-        // rdd.union(loadOneHDU(file))
-        sqlContext.sparkContext.union(rdd, loadOneHDU(file))
-      } else {
-        rdd.union(loadOneEmpty)
-      }
+    val rdd = if (implemented) {
+      sqlContext.sparkContext.union(
+        fns.map(file => loadOneHDU(file))
+      )
+    } else {
+      sqlContext.sparkContext.union(
+        fns.map(file => loadOneEmpty)
+      )
     }
+    // val rdd = sqlContext.sparkContext.union(
+    //   fns.map(file => loadOneHDU(file))
+    // )
+    // for ((file, index) <- fns.slice(1, nFiles).zipWithIndex) {
+    //   rdd = if (implemented) {
+    //     // rdd.union(loadOneHDU(file))
+    //     // sqlContext.sparkContext.union(rdd, loadOneHDU(file))
+    //     rdd.union(loadOneHDU(file))
+    //   } else {
+    //     // rdd.union(loadOneEmpty)
+    //     // sqlContext.sparkContext.union(rdd, loadOneEmpty)
+    //     rdd.union(loadOneEmpty)
+    //   }
+    // }
     rdd
   }
 

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
@@ -313,7 +313,8 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     // Union if more than one file
     for ((file, index) <- fns.slice(1, nFiles).zipWithIndex) {
       rdd = if (implemented) {
-        rdd.union(loadOneHDU(file))
+        // rdd.union(loadOneHDU(file))
+        sqlContext.sparkContext.union(rdd, loadOneHDU(file))
       } else {
         rdd.union(loadOneEmpty)
       }

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
@@ -197,6 +197,9 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     * the same. Throw an AssertionError otherwise.
     * The check is performed only for BINTABLE.
     *
+    * NOTE: This operation is very long for many files! Do not use it for
+    * hundreds of files!
+    *
     * @param listOfFitsFiles : (List[String])
     *   List of files as a list of String.
     * @return (String) the type of HDU: BINTABLE, IMAGE, EMPTY, or
@@ -256,6 +259,8 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     *
     * If the HDU type is not "implemented", return an empty RDD[Row].
     *
+    * NOTE: Schema check needs to be fixed!
+    *
     * @param fn : (String)
     *   Filename of the fits file to be read, or a directory containing FITS files
     *   with the same HDU structure.
@@ -270,7 +275,14 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
 
     // Check that all the files have the same Schema
     // in order to perform the union. Return the HDU type.
-    val implemented = checkSchemaAndReturnType(listOfFitsFiles)
+    // NOTE: This operation is very long for hundreds of files!
+    // NOTE: Limit that to the first 10 files.
+    // NOTE: Need to be fixed!
+    val implemented = if (listOfFitsFiles.size < 10) {
+      checkSchemaAndReturnType(listOfFitsFiles)
+    } else{
+      checkSchemaAndReturnType(listOfFitsFiles.slice(0, 10))
+    }
 
     // Load one or all the FITS files found
     load(listOfFitsFiles, implemented)


### PR DESCRIPTION
### What has changed?

This PR brings two major improvements:
- Solve the multifile problem that was seen in #54 
- Reduce a potential large overhead when reading many files, due to schema checks.

### How this has been tested?

Unit test suite passes + additional integration tests performed. Seem all good, though I need to keep an eye on this

### Is there anything left?

Yes for 20,000+ input files, the job explodes by sending many errors in the same times (probably related to each other):

```
java.lang.AssertionError:
        HDU number 0 does not exist!

java.lang.ArithmeticException: / by zero

java.util.NoSuchElementException: key not found: BITPIX

org.apache.hadoop.hdfs.BlockMissingException: Could not obtain block: BP-1151505977-134.158.75.222-1469858775214:blk_1075726089_1986406

.... (and then loop over those four)
```

I need to investigate a bit more.