### PR TITLE
Update default Spark version for the compilation to 2.3.2 and drop support for Scala 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: scala
 scala:
-  - 2.10.6
   - 2.11.8
 
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,8 @@ lazy val root = (project in file(".")).
    // assemblyShadeRules in assembly := Seq(ShadeRule.rename("nom.**" -> "new_nom.@1").inAll),
    // Put dependencies of the library
    libraryDependencies ++= Seq(
-     "org.apache.spark" %% "spark-core" % "2.1.0" % "provided",
-     "org.apache.spark" %% "spark-sql" % "2.1.0" % "provided",
+     "org.apache.spark" %% "spark-core" % "2.3.2" % "provided",
+     "org.apache.spark" %% "spark-sql" % "2.3.2" % "provided",
      scalaTest % Test
    )
  )


### PR DESCRIPTION
Update default Spark version for the compilation to 2.3.2