### PR TITLE
Issue-62: Add possibility to load a list of comma-separated files.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,8 @@ lazy val root = (project in file(".")).
    // assemblyShadeRules in assembly := Seq(ShadeRule.rename("nom.**" -> "new_nom.@1").inAll),
    // Put dependencies of the library
    libraryDependencies ++= Seq(
-     "org.apache.spark" %% "spark-core" % "2.3.2" % "provided",
-     "org.apache.spark" %% "spark-sql" % "2.3.2" % "provided",
+     "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
+     "org.apache.spark" %% "spark-sql" % "2.4.0" % "provided",
      scalaTest % Test
    )
  )

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
@@ -138,6 +138,8 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     // Check whether we are globbing
     val isGlob : Boolean = Try{fs.globStatus(path).size > 1}.getOrElse(false)
 
+    val isCommaSep : Boolean = Try{fn.split(",").size > 1}.getOrElse(false)
+
     // Check whether we want to load a single FITS file or several
     val isDir : Boolean = fs.isDirectory(path)
     val isFile : Boolean = fs.isFile(path)
@@ -151,6 +153,8 @@ class FitsRelation(parameters: Map[String, String], userSchema: Option[StructTyp
     } else if (isDir) {
       val it = fs.listFiles(path, true)
       getListOfFiles(it).filter{file => file.endsWith(".fits")}
+    } else if (isCommaSep) {
+      fn.split(",").toList
     } else if (isFile){
       List(fn)
     } else {

--- a/src/test/scala/com/astrolabsoftware/sparkfits/packageTest.scala
+++ b/src/test/scala/com/astrolabsoftware/sparkfits/packageTest.scala
@@ -165,6 +165,16 @@ class packageTest extends FunSuite with BeforeAndAfterAll {
     assert(df.count() == 27000)
   }
 
+  test("Multi files test: Can you read several FITS file (comma-separated)?") {
+    val fn = "src/test/resources/dir/test_file.fits,src/test/resources/dir/test_file2.fits"
+    val df = spark.read.format("fits")
+      .option("hdu", 1)
+      .load(fn)
+
+    assert(df.isInstanceOf[DataFrame])
+    assert(df.count() == 27000)
+  }
+
   test("Multi files test: Can you detect an error in reading different FITS file?") {
     val fn = "src/test/resources/dirNotOk"
     val results = spark.read.format("com.astrolabsoftware.sparkfits")


### PR DESCRIPTION
### What is new in this PR?

This PR allows to load a list of comma-separated FITS files as described in #62:

```scala
// Scala
val fns = "/path/to/file1.fits,/path/to/file2.fits,..."
val df = spark.read.format("fits").option("hdu", 1).load(fns)
```

```python
# Python
fns = "/path/to/file1.fits,/path/to/file2.fits,..."
df = spark.read.format("fits").option("hdu", 1).load(fns)
```

### How this has been tested?

New unit test added.

### Other changes?

Bump spark version to 2.4.0 for the build.