### PR TITLE
Bump version: 0.7.1 -> 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [06/2018] **New location**: spark-fits is an official project of [AstroLab](https://astrolabsoftware.github.io/)!
 - [07/2018] **Release**: version 0.5.0, 0.6.0
 - [10/2018] **Release**: version 0.7.0, 0.7.1
+- [12/2018] **Release**: version 0.7.2
 
 ## spark-fits
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import xerial.sbt.Sonatype._
 lazy val root = (project in file(".")).
  settings(
    inThisBuild(List(
-     version      := "0.7.1",
+     version      := "0.7.2",
      mainClass in Compile := Some("com.astrolabsoftware.sparkfits.ReadFits")
    )),
    // Name of the application

--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -20,7 +20,7 @@ another version, feel free to contact us.
 You can link spark-fits to your project (either `spark-shell` or `spark-submit`) by specifying the coordinates:
 
 ```bash
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.7.1" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.7.2" <...>
 ```
 
 It might not contain the latest features though (see *Building from source*).

--- a/docs/02_api.md
+++ b/docs/02_api.md
@@ -20,10 +20,10 @@ coordinates in your `build.sbt`:
 
 ```scala
 // %% will automatically set the Scala version needed for spark-fits
-libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.7.1"
+libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.7.2"
 
 // Alternatively you can also specify directly the Scala version, e.g.
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.7.1"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.7.2"
 ```
 
 #### Scala 2.10.6 and 2.11.X
@@ -58,7 +58,8 @@ Note that the file can be in a local system
 (`path="hdfs://<IP>:<PORT>//path/myfile.fits"`). You can also specify a
 directory containing a set of FITS files
 (`path="hdfs://<IP>:<PORT>//path_to_dir"`) with the same HDU structure, or you
-can apply globbing patterns (`path="hdfs://<IP>:<PORT>//path_to_dir/*.fits"`).
+can apply globbing patterns (`path="hdfs://<IP>:<PORT>//path_to_dir/*.fits"`), or you
+can pass a string of comma-separated files (`path="hdfs://<IP>:<PORT>//path_to_dir/file1.fits,path="hdfs://<IP>:<PORT>//path_to_dir/file2.fits"`).
 The connector will load the data from the same HDU from all the files in
 one single DataFrame. This is particularly useful to manipulate many
 small files written the same way as one.

--- a/docs/03_interactive.md
+++ b/docs/03_interactive.md
@@ -14,14 +14,14 @@ option. For example, to include it when starting the spark shell
 (**Spark compiled with Scala 2.11**):
 
 ```bash
-$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.2
 ```
 
 Using `--packages` ensures that this library and its dependencies will
 be added to the classpath (make sure you use the latest version). In Python, you would do the same
 
 ```bash
-$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.1
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.2
 ```
 
 Alternatively to have the latest development you can download this repo

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -8,7 +8,7 @@ header:
   cta_url: "/docs/installation/"
   caption:
 intro:
-  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.7.1">Latest release: 0.7.1</a>'
+  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.7.2">Latest release: 0.7.2</a>'
 excerpt: '{::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 feature_row:
   - image_path:

--- a/examples/python/im2cat.py
+++ b/examples/python/im2cat.py
@@ -133,14 +133,14 @@ def aggregate_ccd(args):
         HDU[hdustop] included.
     """
     df_init = spark.read\
-        .format("com.astrolabsoftware.sparkfits")\
+        .format("fits")\
         .option("hdu", args.hdustart)\
         .load(args.inputpath)
     imRDD = rowdf_into_imagerdd(df_init)
 
     for hdu in range(args.hdustart + 1, args.hdustop + 1):
         df = spark.read\
-            .format("com.astrolabsoftware.sparkfits")\
+            .format("fits")\
             .option("hdu", hdu)\
             .load(args.inputpath)
         imRDD = imRDD.union(rowdf_into_imagerdd(df))

--- a/run_image_python.sh
+++ b/run_image_python.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="file://$PWD/src/test/resources/sdss.fits"
@@ -32,6 +32,6 @@ hdustop=2
 # Run it!
 spark-submit \
   --master local[*] \
-  --jars target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar \
+  --jars target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar \
   examples/python/im2cat.py \
   -inputpath $fitsfn -hdustart $hdustart -hdustop $hdustop -log_level ERROR

--- a/run_java.sh
+++ b/run_java.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="file://$PWD/src/test/resources/test_file.fits"
@@ -30,5 +30,5 @@ fitsfn="file://$PWD/src/test/resources/test_file.fits"
 spark-submit \
   --master local[*] \
   --class com.astrolabsoftware.sparkfits.ReadFitsJ \
-  target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar \
+  target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar \
   $fitsfn

--- a/run_python.sh
+++ b/run_python.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="file://$PWD/src/test/resources/test_file.fits"
@@ -29,6 +29,6 @@ fitsfn="file://$PWD/src/test/resources/test_file.fits"
 # Run it!
 spark-submit \
   --master local[*] \
-  --jars target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar \
+  --jars target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar \
   examples/python/readfits.py \
   -inputpath $fitsfn -log_level ERROR

--- a/run_python_cluster.sh
+++ b/run_python_cluster.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
@@ -29,7 +29,7 @@ fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
 master="--master spark://134.158.75.222:7077"
 memory="--driver-memory 4g --executor-memory 18g"
 conf="--conf spark.kryoserializer.buffer.max=1g"
-jars="--jars target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar"
+jars="--jars target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar"
 pgm="src/main/python/ReadImage.py"
 imput="-inputpath $fitsfn"
 

--- a/run_python_cori.sh
+++ b/run_python_cori.sh
@@ -10,14 +10,14 @@ module load spark
 module load sbt
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="/global/cscratch1/sd/<user>/<path>"
@@ -27,7 +27,7 @@ start-all.sh
 shifter spark-submit \
   --master $SPARKURL \
   --driver-memory 15g --executor-memory 50g --executor-cores 32 --total-executor-cores 192 \
-  --jars target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar \
+  --jars target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar \
   examples/python/readfits.py \
   -inputpath $fitsfn
 stop-all.sh

--- a/run_scala.sh
+++ b/run_scala.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="file://$PWD/src/test/resources/test_file.fits"
@@ -30,5 +30,5 @@ fitsfn="file://$PWD/src/test/resources/test_file.fits"
 spark-submit \
   --master local[*] \
   --class com.astrolabsoftware.sparkfits.ReadFits \
-  target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar \
+  target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar \
   $fitsfn

--- a/run_scala_cluster.sh
+++ b/run_scala_cluster.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 #fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
@@ -32,7 +32,7 @@ fitsfn="hdfs://134.158.75.222:8020//lsst/tests/toTest/tst0009.fits"
 
 
 # Run it!
-cmd="spark-submit --master spark://134.158.75.222:7077 --driver-memory 4g --executor-memory 18g --class com.astrolabsoftware.sparkfits.ReadFits target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar $fitsfn"
+cmd="spark-submit --master spark://134.158.75.222:7077 --driver-memory 4g --executor-memory 18g --class com.astrolabsoftware.sparkfits.ReadFits target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar $fitsfn"
 
 $cmd
 

--- a/run_scala_cluster_image.sh
+++ b/run_scala_cluster_image.sh
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="hdfs://134.158.75.222:8020//lsst/tests/tst0009.fits"
@@ -29,6 +29,6 @@ fitsfn="hdfs://134.158.75.222:8020//lsst/images/a.fits"
 
 
 # Run it!
-cmd="spark-submit --master spark://134.158.75.222:7077 --driver-memory 4g --executor-memory 18g --class com.astrolabsoftware.sparkfits.ReadImage target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar $fitsfn"
+cmd="spark-submit --master spark://134.158.75.222:7077 --driver-memory 4g --executor-memory 18g --class com.astrolabsoftware.sparkfits.ReadImage target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar $fitsfn"
 
 $cmd

--- a/run_scala_cori.sh
+++ b/run_scala_cori.sh
@@ -10,14 +10,14 @@ module load spark
 module load sbt
 
 ## SBT Version
-SBT_VERSION=2.11.8
-SBT_VERSION_SPARK=2.11
+SCALA_VERSION=2.11.8
+SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.1
+VERSION=0.7.2
 
 # Package it
-sbt ++${SBT_VERSION} package
+sbt ++${SCALA_VERSION} package
 
 # Parameters (put your file)
 fitsfn="/global/cscratch1/sd/<user>/<path>"
@@ -28,6 +28,6 @@ shifter spark-submit \
   --master $SPARKURL \
   --driver-memory 15g --executor-memory 50g --executor-cores 32 --total-executor-cores 192 \
   --class com.astrolabsoftware.sparkfits.ReadFits \
-  target/scala-${SBT_VERSION_SPARK}/spark-fits_${SBT_VERSION_SPARK}-${VERSION}.jar \
+  target/scala-${SCALA_VERSION_SPARK}/spark-fits_${SCALA_VERSION_SPARK}-${VERSION}.jar \
   $fitsfn
 stop-all.sh

--- a/src/main/scala/com/astrolabsoftware/sparkfits/DefaultSource.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/DefaultSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsFileInputFormat.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsFileInputFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsHdu.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsHdu.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsHduBintable.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsHduBintable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsHduImage.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsHduImage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsLib.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsLib.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsSchema.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsSchema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsSourceRelation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/ReadFits.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/ReadFits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/ReadImage.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/ReadImage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/com/astrolabsoftware/sparkfits/package.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/astrolabsoftware/sparkfits/FitsLibTest.scala
+++ b/src/test/scala/com/astrolabsoftware/sparkfits/FitsLibTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/astrolabsoftware/sparkfits/FitsSchemaTest.scala
+++ b/src/test/scala/com/astrolabsoftware/sparkfits/FitsSchemaTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/astrolabsoftware/sparkfits/ReadFitsTest.scala
+++ b/src/test/scala/com/astrolabsoftware/sparkfits/ReadFitsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/com/astrolabsoftware/sparkfits/packageTest.scala
+++ b/src/test/scala/com/astrolabsoftware/sparkfits/packageTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Julien Peloton
+ * Copyright 2018 AstroLab Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test.sh
+++ b/test.sh
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 ## SBT Version
-SBT_VERSION=2.11.8
+SCALA_VERSION=2.11.8
 
 # Clean and launch the test suite
-sbt ++${SBT_VERSION} clean
-sbt ++${SBT_VERSION} coverage test coverageReport
+sbt ++${SCALA_VERSION} clean
+sbt ++${SCALA_VERSION} coverage test coverageReport


### PR DESCRIPTION
## 0.7.2

- Update default Spark version for the compilation to 2.3.2 and drop support for Scala 2.10 (#58)
- ISSUE-59: Add Unsigned Byte in the handled types (#60)
- Issue-62: Add possibility to load a list of comma-separated files (#63)
- Update default Spark version for the compilation to 2.4.0 (#63)

Big thanks to @jacobic for spotting bugs and suggesting enhancement!