### PR TITLE
S3 compatibility

### DIFF
--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsLib.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsLib.scala
@@ -266,7 +266,12 @@ object FitsLib {
 
         // Move to the another HDU if needed
         hduTmp = hduTmp + 1
-        data.seek(blockStop)
+
+        // S3 filesystem complains in the case of
+        // seek(len(file)), while HDFS does not.
+        Try{
+          data.seek(blockStop)
+        }.getOrElse{data.seek(blockStop - 1)}
 
       } while (hduTmp < hduIndex + 1)
 
@@ -401,7 +406,11 @@ object FitsLib {
             datalen + FITSBLOCK_SIZE_BYTES - (datalen % FITSBLOCK_SIZE_BYTES)
           }
 
-          data.seek(data.getPos + skipBytes)
+          // S3 filesystem complains in the case of
+          // seek(len(file)), while HDFS does not.
+          Try{
+            data.seek(data.getPos + skipBytes)
+          }.getOrElse{data.seek(data.getPos + skipBytes - 1)}
 
           // Move to the another HDU if needed
           currentHduIndex = currentHduIndex + 1

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
@@ -383,6 +383,7 @@ class FitsRecordReader extends RecordReader[LongWritable, Seq[Row]] {
 
     // We reached the end of the split.
     // We will now go to another split (if more available)
+    fits.data.close()
     false
   }
 }


### PR DESCRIPTION
This PR solves a bug when trying to read fits file on S3 by making an exception when `seek(len(file))` is called. This is mandatory for usage on s3 filesystems. See [HADOOP-11270](https://jira.apache.org/jira/browse/HADOOP-11270) for a detailed discussion, and [The Hadoop FileSystem API Definition](http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/filesystem/index.html).

This fixes #65.