### PR TITLE
Bump version: 0.7.2 -> 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [07/2018] **Release**: version 0.5.0, 0.6.0
 - [10/2018] **Release**: version 0.7.0, 0.7.1
 - [12/2018] **Release**: version 0.7.2
+- [03/2019] **Release**: version 0.7.3
 
 ## spark-fits
 
@@ -26,7 +27,17 @@ Spark](http://spark.apache.org/):
 -   A Scala library to manipulate FITS file.
 
 The user interface has been done to be the same as other built-in Spark
-data sources (CSV, JSON, Avro, Parquet, etc). Note that spark-fits follows Apache Spark Data Source V1 ([plan](https://github.com/astrolabsoftware/spark-fits/issues/50) to migrate to V2). See our [website](https://astrolabsoftware.github.io/spark-fits/) for more information.
+data sources (CSV, JSON, Avro, Parquet, etc). Note that spark-fits follows Apache Spark Data Source V1 ([plan](https://github.com/astrolabsoftware/spark-fits/issues/50) to migrate to V2). See our [website](https://astrolabsoftware.github.io/spark-fits/) for more information. To include spark-fits in your job:
+
+```bash
+spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.7.3" <...>
+```
+
+or you can link against this library in your program at the following coordinates in your build.sbt
+
+```scala
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.7.3"
+```
 
 Currently available:
 
@@ -46,7 +57,7 @@ us (issues or PR) so that we fix the problem asap!
 ## TODO list
 
 - Define custom Hadoop InputFile.
-- Adapt to S3 usage?
+- Migrate to Spark DataSource V2
 
 ## Support
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import xerial.sbt.Sonatype._
 lazy val root = (project in file(".")).
  settings(
    inThisBuild(List(
-     version      := "0.7.2",
+     version      := "0.7.3",
      mainClass in Compile := Some("com.astrolabsoftware.sparkfits.ReadFits")
    )),
    // Name of the application

--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -20,7 +20,7 @@ another version, feel free to contact us.
 You can link spark-fits to your project (either `spark-shell` or `spark-submit`) by specifying the coordinates:
 
 ```bash
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.7.2" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.7.3" <...>
 ```
 
 It might not contain the latest features though (see *Building from source*).

--- a/docs/02_api.md
+++ b/docs/02_api.md
@@ -20,10 +20,10 @@ coordinates in your `build.sbt`:
 
 ```scala
 // %% will automatically set the Scala version needed for spark-fits
-libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.7.2"
+libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.7.3"
 
 // Alternatively you can also specify directly the Scala version, e.g.
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.7.2"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.7.3"
 ```
 
 #### Scala 2.10.6 and 2.11.X

--- a/docs/03_interactive.md
+++ b/docs/03_interactive.md
@@ -14,14 +14,14 @@ option. For example, to include it when starting the spark shell
 (**Spark compiled with Scala 2.11**):
 
 ```bash
-$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.2
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.3
 ```
 
 Using `--packages` ensures that this library and its dependencies will
 be added to the classpath (make sure you use the latest version). In Python, you would do the same
 
 ```bash
-$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.2
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.3
 ```
 
 Alternatively to have the latest development you can download this repo

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -8,7 +8,7 @@ header:
   cta_url: "/docs/installation/"
   caption:
 intro:
-  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.7.2">Latest release: 0.7.2</a>'
+  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.7.3">Latest release: 0.7.3</a>'
 excerpt: '{::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 feature_row:
   - image_path:

--- a/run_image_python.sh
+++ b/run_image_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_java.sh
+++ b/run_java.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python.sh
+++ b/run_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cluster.sh
+++ b/run_python_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cori.sh
+++ b/run_python_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala.sh
+++ b/run_scala.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster.sh
+++ b/run_scala_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster_image.sh
+++ b/run_scala_cluster_image.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cori.sh
+++ b/run_scala_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.2
+VERSION=0.7.3
 
 # Package it
 sbt ++${SCALA_VERSION} package


### PR DESCRIPTION
## 0.7.3

- Make spark-fits running on S3 (#66)

Still a few things to understand - but likely to be related to S3 itself (#67)