### PR TITLE
Bump version 0.7.3 -> 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 - [07/2018] **Release**: version 0.5.0, 0.6.0
 - [10/2018] **Release**: version 0.7.0, 0.7.1
 - [12/2018] **Release**: version 0.7.2
-- [03/2019] **Release**: version 0.7.3
+- [03/2019] **Release**: version 0.8.0
+- [05/2019] **Release**: version 0.8.0
 
 ## spark-fits
 
@@ -30,13 +31,21 @@ The user interface has been done to be the same as other built-in Spark
 data sources (CSV, JSON, Avro, Parquet, etc). Note that spark-fits follows Apache Spark Data Source V1 ([plan](https://github.com/astrolabsoftware/spark-fits/issues/50) to migrate to V2). See our [website](https://astrolabsoftware.github.io/spark-fits/) for more information. To include spark-fits in your job:
 
 ```bash
-spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.7.3" <...>
+# Scala 2.11
+spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.0" <...>
+
+# Scala 2.12
+spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.0" <...>
 ```
 
 or you can link against this library in your program at the following coordinates in your build.sbt
 
 ```scala
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.7.3"
+// Scala 2.11
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.0"
+
+// Scala 2.12
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.12" % "0.8.0"
 ```
 
 Currently available:

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import xerial.sbt.Sonatype._
 lazy val root = (project in file(".")).
  settings(
    inThisBuild(List(
-     version      := "0.7.3",
+     version      := "0.8.0",
      mainClass in Compile := Some("com.astrolabsoftware.sparkfits.ReadFits")
    )),
    // Name of the application

--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -12,7 +12,7 @@ redirect_from:
 ## Requirements
 
 This library requires Spark 2.0+ (not tested for earlier version). The
-library has been tested with Scala 2.10.6 and 2.11.X. If you want to use
+library is tested with Scala 2.11 & 2.12. If you want to use
 another version, feel free to contact us.
 
 ## Including spark-fits in your project
@@ -20,7 +20,11 @@ another version, feel free to contact us.
 You can link spark-fits to your project (either `spark-shell` or `spark-submit`) by specifying the coordinates:
 
 ```bash
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.7.3" <...>
+# Scala 2.11
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.0" <...>
+
+# Scala 2.12
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.0" <...>
 ```
 
 It might not contain the latest features though (see *Building from source*).

--- a/docs/02_api.md
+++ b/docs/02_api.md
@@ -20,15 +20,15 @@ coordinates in your `build.sbt`:
 
 ```scala
 // %% will automatically set the Scala version needed for spark-fits
-libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.7.3"
+libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.8.0"
 
 // Alternatively you can also specify directly the Scala version, e.g.
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.7.3"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.0"
 ```
 
 #### Scala 2.10.6 and 2.11.X
 
-Here is the minimal syntax in Scala 2.10.6 and 2.11.X to play with the
+Here is the minimal syntax in Scala 2.11 and 2.12 to play with the
 package:
 
 ```scala

--- a/docs/03_interactive.md
+++ b/docs/03_interactive.md
@@ -10,18 +10,25 @@ date: 2018-06-15 22:31:13 +0200
 ## Using with spark-shell/pyspark
 
 This package can be added to Spark using the `--packages` command line
-option. For example, to include it when starting the spark shell
-(**Spark compiled with Scala 2.11**):
+option. For example, to include it when starting the spark shell:
 
 ```bash
-$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.3
+# Scala 2.11
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.0
+
+# Scala 2.12
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.0
 ```
 
 Using `--packages` ensures that this library and its dependencies will
 be added to the classpath (make sure you use the latest version). In Python, you would do the same
 
 ```bash
-$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.3
+# Scala 2.11
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.0
+
+# Scala 2.11
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.0
 ```
 
 Alternatively to have the latest development you can download this repo

--- a/docs/03_interactive.md
+++ b/docs/03_interactive.md
@@ -27,7 +27,7 @@ be added to the classpath (make sure you use the latest version). In Python, you
 # Scala 2.11
 $SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.0
 
-# Scala 2.11
+# Scala 2.12
 $SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.0
 ```
 

--- a/docs/04_batch.md
+++ b/docs/04_batch.md
@@ -15,7 +15,7 @@ In addition, we provide scripts to run spark-fits applications at NERSC, Califor
 See the two shell scripts at the root of the package
 
 ```bash
-./run_scala.sh  # Scala (bintable HDU)
+./run_scala-2.1X.sh  # Scala (bintable HDU)
 ./run_python.sh # Python (bintable HDU)
 ./run_image python.sh # Python (image HDU)
 ```

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -8,7 +8,7 @@ header:
   cta_url: "/docs/installation/"
   caption:
 intro:
-  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.7.3">Latest release: 0.7.3</a>'
+  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.8.0">Latest release: 0.8.0</a>'
 excerpt: '{::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 feature_row:
   - image_path:

--- a/docs/about.md
+++ b/docs/about.md
@@ -19,6 +19,7 @@ data sources (CSV, JSON, Avro, Parquet, etc).
 
 Currently available:
 
+-   Support for Scala 2.11 & Scala 2.12
 -   Read fits file and organize the HDU data into DataFrames.
 -   Automatically distribute bintable rows over machines.
 -   Automatically distribute image rows over machines.

--- a/run_image_python.sh
+++ b/run_image_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_java.sh
+++ b/run_java.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python.sh
+++ b/run_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cluster.sh
+++ b/run_python_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cori.sh
+++ b/run_python_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster.sh
+++ b/run_scala_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster_image.sh
+++ b/run_scala_cluster_image.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cori.sh
+++ b/run_scala_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.0
 
 # Package it
 sbt ++${SCALA_VERSION} package


### PR DESCRIPTION
This PR updates the library version from 0.7.3 to 0.8.0

### 0.8.0
* Support for multivalued columns (#70 )
* Better handling of the `recordLength` option (#72 )
* Support for Scala 2.12 (#74 )

Thanks @jacobic for reporting issues and bugs!