### PR TITLE
Issue 76: preserve column order from the columns option

### DIFF
--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsHduBintable.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsHduBintable.scala
@@ -46,8 +46,12 @@ object FitsHduBintable {
       colNames.values.toList.asInstanceOf[List[String]]
     }
 
-    val colPositions = selectedColNames.map(
-      x => getColumnPos(keyValues, x)).toList.sorted
+    val colPositions = if (selectedColumns != null) {
+      selectedColNames.map(x => getColumnPos(keyValues, x)).toList
+    } else {
+      selectedColNames.map(x => getColumnPos(keyValues, x)).toList.sorted
+    }
+
 
     val rowTypes = getColTypes(keyValues)
 


### PR DESCRIPTION
This PR fixes the wrong column ordering when the option `columns` was used:

```python
df = spark.read.format("fits")\
  .option("hdu", 1)\
  .load("src/test/resources/test_file.fits")

df.show(2)
# +----------+--------+-------------------+-----+-----+
# |    target|      RA|                Dec|Index|RunId|
# +----------+--------+-------------------+-----+-----+
# |NGC0000000|3.448297|-0.3387486324784641|    0|    1|
# |NGC0000001|4.493667|-1.4414990980543227|    1|    1|
# +----------+--------+-------------------+-----+-----+

df = spark.read.format("fits")\
  .option("hdu", 1)\
  .option("columns", "Index,target,RunId")
  .load("src/test/resources/test_file.fits")

df.show(2)
# +-----+----------+-----+
# |Index|    target|RunId|
# +-----+----------+-----+
# |    0|NGC0000000|    1|
# |    1|NGC0000001|    1|
# +-----+----------+-----+
```