### PR TITLE
Bump version 0.8.0 -> 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - [10/2018] **Release**: version 0.7.0, 0.7.1
 - [12/2018] **Release**: version 0.7.2
 - [03/2019] **Release**: version 0.7.3
-- [05/2019] **Release**: version 0.8.0
+- [05/2019] **Release**: version 0.8.0, 0.8.1
 
 ## spark-fits
 
@@ -32,20 +32,20 @@ data sources (CSV, JSON, Avro, Parquet, etc). Note that spark-fits follows Apach
 
 ```bash
 # Scala 2.11
-spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.0" <...>
+spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.1" <...>
 
 # Scala 2.12
-spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.0" <...>
+spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.1" <...>
 ```
 
 or you can link against this library in your program at the following coordinates in your build.sbt
 
 ```scala
 // Scala 2.11
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.0"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.1"
 
 // Scala 2.12
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.12" % "0.8.0"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.12" % "0.8.1"
 ```
 
 Currently available:

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import xerial.sbt.Sonatype._
 lazy val root = (project in file(".")).
  settings(
    inThisBuild(List(
-     version      := "0.8.0",
+     version      := "0.8.1",
      mainClass in Compile := Some("com.astrolabsoftware.sparkfits.ReadFits")
    )),
    // Name of the application

--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -21,10 +21,10 @@ You can link spark-fits to your project (either `spark-shell` or `spark-submit`)
 
 ```bash
 # Scala 2.11
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.0" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.1" <...>
 
 # Scala 2.12
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.0" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.1" <...>
 ```
 
 It might not contain the latest features though (see *Building from source*).

--- a/docs/02_api.md
+++ b/docs/02_api.md
@@ -20,10 +20,10 @@ coordinates in your `build.sbt`:
 
 ```scala
 // %% will automatically set the Scala version needed for spark-fits
-libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.8.0"
+libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.8.1"
 
 // Alternatively you can also specify directly the Scala version, e.g.
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.0"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.1"
 ```
 
 #### Scala 2.10.6 and 2.11.X

--- a/docs/03_interactive.md
+++ b/docs/03_interactive.md
@@ -14,10 +14,10 @@ option. For example, to include it when starting the spark shell:
 
 ```bash
 # Scala 2.11
-$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.0
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.1
 
 # Scala 2.12
-$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.0
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.1
 ```
 
 Using `--packages` ensures that this library and its dependencies will
@@ -25,10 +25,10 @@ be added to the classpath (make sure you use the latest version). In Python, you
 
 ```bash
 # Scala 2.11
-$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.0
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.1
 
 # Scala 2.12
-$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.0
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.1
 ```
 
 Alternatively to have the latest development you can download this repo

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -8,7 +8,7 @@ header:
   cta_url: "/docs/installation/"
   caption:
 intro:
-  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.8.0">Latest release: 0.8.0</a>'
+  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.8.1">Latest release: 0.8.1</a>'
 excerpt: '{::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 feature_row:
   - image_path:

--- a/run_image_python.sh
+++ b/run_image_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_java.sh
+++ b/run_java.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python.sh
+++ b/run_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cluster.sh
+++ b/run_python_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cori.sh
+++ b/run_python_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala-2.11.sh
+++ b/run_scala-2.11.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala-2.12.sh
+++ b/run_scala-2.12.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.12.8
 SCALA_VERSION_SPARK=2.12
 
 ## Package version
-VERSION=0.7.3
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster.sh
+++ b/run_scala_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster_image.sh
+++ b/run_scala_cluster_image.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cori.sh
+++ b/run_scala_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.0
+VERSION=0.8.1
 
 # Package it
 sbt ++${SCALA_VERSION} package


### PR DESCRIPTION
This PR updates the library version from 0.8.0 to 0.8.1

### 0.8.1
* Preserve column order from the columns option (#77 )
* 1X should be viewed as scalar (#79 )

Thanks @jacobic and @marcol480 for reporting issues and bugs!