### PR TITLE
Switch to openjdk8 for compatibility with xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
   - 2.12.8
 
 jdk:
-  - oraclejdk8
+  - openjdk8 
 cache:
   directories:
     - $HOME/.m2/repository


### PR DESCRIPTION
Link to issue: #88 

This PR changes the JDK from `oraclejdk8` to `openjdk8` since the former is no more available by default in `xenial`.