### PR TITLE
Wrong shift in the start of the data block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - $HOME/.sbt/launchers/
 
 before_script:
-  - mkdir -p $HOME/.sbt/launchers/0.13.8/
-  - curl -L -o $HOME/.sbt/launchers/0.13.8/sbt-launch.jar https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.8/sbt-launch.jar
+  - mkdir -p $HOME/.sbt/launchers/0.13.16/
+  - curl -L -o $HOME/.sbt/launchers/0.13.16/sbt-launch.jar https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.16/sbt-launch.jar
 
 script:
   - echo "Scala version:" $TRAVIS_SCALA_VERSION

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.8

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
@@ -240,7 +240,7 @@ class FitsRecordReader extends RecordReader[LongWritable, Seq[Row]] {
       // beginning of the data block for the first valid block.
 
       // We shift the start to where the data block starts
-      var shift = -startstop.dataStart
+      var shift = -startstop.dataStart + 1
 
       splitStart = if((splitStart_tmp) % rowSizeLong != 0 &&
         splitStart_tmp != startstop.dataStart && splitStart_tmp != 0) {

--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsRecordReader.scala
@@ -240,16 +240,19 @@ class FitsRecordReader extends RecordReader[LongWritable, Seq[Row]] {
       // beginning of the data block for the first valid block.
 
       // We shift the start to where the data block starts
-      var shift = -startstop.dataStart + 1
+      var shift = -startstop.dataStart
 
       splitStart = if((splitStart_tmp) % rowSizeLong != 0 &&
         splitStart_tmp != startstop.dataStart && splitStart_tmp != 0) {
 
         // Decrement the starting index to fully catch the line we are sitting on
+        // Only do it if necessary, otherwise you'll get duplicate (#93)
         var tmp_byte = 0
-        do {
-          tmp_byte = tmp_byte - 1
-        } while ((splitStart_tmp + tmp_byte + shift) % rowSizeLong != 0)
+        if ((splitStart_tmp + tmp_byte + shift) % rowSizeLong != 0) {
+          do {
+            tmp_byte = tmp_byte - 1
+          } while ((splitStart_tmp + tmp_byte + shift) % rowSizeLong != 0)
+        }
 
         // Return offseted starting index
         splitStart_tmp + tmp_byte


### PR DESCRIPTION
Link to issue: #93 

This PR corrects the index mismatch in the start of the data block that was sometimes causing one duplicated row.