### PR TITLE
Bump from version 0.8.4 to version 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [05/2019] **Release**: version 0.8.0, 0.8.1, 0.8.2
 - [06/2019] **Release**: version 0.8.3
 - [05/2020] **Release**: version 0.8.4
+- [07/2020] **Release**: version 0.9.0
 
 ## spark-fits
 
@@ -34,20 +35,20 @@ data sources (CSV, JSON, Avro, Parquet, etc). Note that spark-fits follows Apach
 
 ```bash
 # Scala 2.11
-spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.4" <...>
+spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.9.0" <...>
 
 # Scala 2.12
-spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.4" <...>
+spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.9.0" <...>
 ```
 
 or you can link against this library in your program at the following coordinates in your build.sbt
 
 ```scala
 // Scala 2.11
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.4"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.9.0"
 
 // Scala 2.12
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.12" % "0.8.4"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.12" % "0.9.0"
 ```
 
 Currently available:

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import xerial.sbt.Sonatype._
 lazy val root = (project in file(".")).
  settings(
    inThisBuild(List(
-     version      := "0.8.4",
+     version      := "0.9.0",
      mainClass in Compile := Some("com.astrolabsoftware.sparkfits.ReadFits")
    )),
    // Name of the application
@@ -81,3 +81,5 @@ publishTo := {
  else
   Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
+
+useGpg := true

--- a/docs/01_installation.md
+++ b/docs/01_installation.md
@@ -21,10 +21,10 @@ You can link spark-fits to your project (either `spark-shell` or `spark-submit`)
 
 ```bash
 # Scala 2.11
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.8.4" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.11:0.9.0" <...>
 
 # Scala 2.12
-toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.8.4" <...>
+toto:~$ spark-submit --packages "com.github.astrolabsoftware:spark-fits_2.12:0.9.0" <...>
 ```
 
 It might not contain the latest features though (see *Building from source*).

--- a/docs/02_api.md
+++ b/docs/02_api.md
@@ -20,10 +20,10 @@ coordinates in your `build.sbt`:
 
 ```scala
 // %% will automatically set the Scala version needed for spark-fits
-libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.8.4"
+libraryDependencies += "com.github.astrolabsoftware" %% "spark-fits" % "0.9.0"
 
 // Alternatively you can also specify directly the Scala version, e.g.
-libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.8.4"
+libraryDependencies += "com.github.astrolabsoftware" % "spark-fits_2.11" % "0.9.0"
 ```
 
 #### Scala 2.10.6 and 2.11.X

--- a/docs/03_interactive.md
+++ b/docs/03_interactive.md
@@ -14,10 +14,10 @@ option. For example, to include it when starting the spark shell:
 
 ```bash
 # Scala 2.11
-$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.4
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.11:0.9.0
 
 # Scala 2.12
-$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.4
+$SPARK_HOME/bin/spark-shell --packages com.github.astrolabsoftware:spark-fits_2.12:0.9.0
 ```
 
 Using `--packages` ensures that this library and its dependencies will
@@ -25,10 +25,10 @@ be added to the classpath (make sure you use the latest version). In Python, you
 
 ```bash
 # Scala 2.11
-$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.4
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.11:0.9.0
 
 # Scala 2.12
-$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.12:0.8.4
+$SPARK_HOME/bin/pyspark --packages com.github.astrolabsoftware:spark-fits_2.12:0.9.0
 ```
 
 Alternatively to have the latest development you can download this repo
@@ -59,7 +59,7 @@ export PYSPARK_DRIVER_PYTHON_OPTS="path/to/jupyter-notebook"
 $SPARK_HOME/bin/pyspark --jars /path/to/jar/<spark-fits.jar>
 ```
 See
-[here](https://spark.apache.org/docs/0.9.0/python-programming-guide.html)
+[here](https://spark.apache.org/docs/latest/python-programming-guide.html)
 for more options for pyspark. To build the JAR, just run
 `sbt ++{SBT_VERSION} package` from the root of the package (see
 `run_*.sh` scripts). Here is an example in the spark-shell:

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -8,7 +8,7 @@ header:
   cta_url: "/docs/installation/"
   caption:
 intro:
-  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.8.4">Latest release: 0.8.4</a>'
+  - excerpt: '<p><font size="6">Distribute FITS data with Apache Spark: Binary tables, images and more!</font></p><br /><a href="https://github.com/astrolabsoftware/spark-fits/releases/tag/0.9.0">Latest release: 0.9.0</a>'
 excerpt: '{::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=astrolabsoftware&repo=spark-fits&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 feature_row:
   - image_path:

--- a/run_image_python.sh
+++ b/run_image_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_java.sh
+++ b/run_java.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python.sh
+++ b/run_python.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cluster.sh
+++ b/run_python_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_python_cori.sh
+++ b/run_python_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala-2.11.sh
+++ b/run_scala-2.11.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala-2.12.sh
+++ b/run_scala-2.12.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.12.8
 SCALA_VERSION_SPARK=2.12
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster.sh
+++ b/run_scala_cluster.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cluster_image.sh
+++ b/run_scala_cluster_image.sh
@@ -18,7 +18,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package

--- a/run_scala_cori.sh
+++ b/run_scala_cori.sh
@@ -14,7 +14,7 @@ SCALA_VERSION=2.11.8
 SCALA_VERSION_SPARK=2.11
 
 ## Package version
-VERSION=0.8.4
+VERSION=0.9.0
 
 # Package it
 sbt ++${SCALA_VERSION} package


### PR DESCRIPTION
This PR bumps the software version from 0.8.4 to 0.9.0

### 0.9.0

- Add image index to each row when reading images (#97)

known issues: image indexing does not work for very small images. This will be fixed in a future release.

Thanks to @GeoffDuniam for contributing to this release!