### PR TITLE
Set Scala version to 2.12.8 and SBT version to 1.4.9 in build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,10 @@ lazy val root = (project in file(".")).
      version      := "1.0.0",
      mainClass in Compile := Some("com.astrolabsoftware.sparkfits.ReadFits")
    )),
+
+   //Scala version
+   scalaVersion := "2.12.8",
+
    // Name of the application
    name := "spark-fits",
    // Name of the orga

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.4.9


### PR DESCRIPTION
Building the package and the tests failed unless the Scala and SBT versions were specified.  
This might've been an environment issue, but wanted to share, in case it's useful.