### PR TITLE
Added Fits.getHDUFullHeader to get original HDU header

### DIFF
--- a/src/main/scala/com/astrolabsoftware/sparkfits/FitsLib.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/FitsLib.scala
@@ -208,6 +208,7 @@ object FitsLib {
     val blockHeader = if (conf.get(hdfsPath + "_header") != null) {
       retrieveHeader
     } else readFullHeaderBlocks
+    val fullHeaderBlock = blockHeader
     resetCursorAtHeader
 
     // Check whether we know the HDU type.
@@ -235,6 +236,16 @@ object FitsLib {
           You specified a recordLength option too small compared to the FITS row size:
           $recordLength B < $rowSize B """)
       }
+    }
+
+    /**
+      * Give access to full header of HDU
+      *
+      * @return (Array[String])
+      *
+      */
+    def getHDUFullHeader : Array[String] = {
+      fullHeaderBlock
     }
 
     /**

--- a/src/main/scala/com/astrolabsoftware/sparkfits/ReadFits.scala
+++ b/src/main/scala/com/astrolabsoftware/sparkfits/ReadFits.scala
@@ -15,6 +15,9 @@
  */
 package com.astrolabsoftware.sparkfits
 
+import com.astrolabsoftware.sparkfits.FitsLib.Fits
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 
@@ -49,6 +52,14 @@ object ReadFits {
 
       val count = df.count()
       println("Total rows: " + count.toString)
+
+      println("getHDUFullHeader>")
+      val hadoopconf = new Configuration()
+      val testpath = new Path(args(0).toString)
+      val fitsobj = new Fits(testpath, hadoopconf, 0)
+      for (elem <- fitsobj.getHDUFullHeader) {
+        println(elem)
+      }
     }
   }
 }


### PR DESCRIPTION
Returned Array includes header text in original sequence/order
including COMMENTS and HISTORY lines
Example call added to ReadFits.scala
The header text is stored in new variable so performance and/or memory usage might be affected